### PR TITLE
fix: public/images の symlink を相対パスに

### DIFF
--- a/public/images
+++ b/public/images
@@ -1,1 +1,1 @@
-/Users/mizzy/src/github.com/hotel-memo/hotel-memo.github.io/content/images
+../content/images


### PR DESCRIPTION
## Summary

- `public/images` の symlink が絶対パス (`/Users/mizzy/...`) で記録されていたため、CI 上の `astro build` が `ENOENT: no such file or directory, stat '/home/runner/.../public/images'` で失敗していた
- 相対パス (`../content/images`) に張り直して CI でも解決できるようにする
- 直前の deploy run: https://github.com/hotel-memo/hotel-memo.github.io/actions/runs/27545006028

## Test plan

- [ ] このブランチに対する CI を流すか、merge 後の deploy workflow が成功すること
- [ ] 本番に画像が 200 OK で配信されること