### PR TITLE
fix: 写真セクション配下の h3 見出しを削除してグリッド表示を整える

### DIFF
--- a/content/memos/hilton/doubletree-tokyo-ariake/guest-room-high-floor.md
+++ b/content/memos/hilton/doubletree-tokyo-ariake/guest-room-high-floor.md
@@ -25,28 +25,20 @@ og_cover: /images/2025/07/Gvf8xizaMAAya7X.jpeg
 
 ## 写真
 
-### ワークチェア（オカムラ mode）
 ![](/images/2025/07/Gvf4r7aakAEk1t5.jpeg)
 
-### デスク周り
 ![](/images/2025/07/Gvf8xizaMAAya7X.jpeg)
 
-### 無料の水
 ![](/images/2025/07/Gvkoy_abAAA_3wA.jpeg)
 
-### 朝食会場（All-Day Dining "Saus"）
-
 ![](/images/2025/07/2017733_98gFs5L3K_4p9-aURTl30chO3XGZmb1guEVNp2qI4Xk.jpg)
-### ダイヤモンド会員朝食会場（Brew33 Bar）
 
 ![](/images/2025/07/GvnBaVKbsAA7-UG.jpeg)
 
 ![](/images/2025/07/GvsOVKubsAQmJ22.jpeg)
 
-### All-Day Dining "Saus"での昼食
 ![](/images/2025/07/GvtI5OVasAAYjOg.jpeg)
 
-### ダイヤモンド会員特典のスタバのコーヒー（ロビーラウンジ）
 ![](/images/2025/07/Gvsyj3UbsAAt-uO.jpeg)
 
 ## 部屋の設備・特徴

--- a/content/memos/hilton/doubletree-tokyo-ariake/guest-room.md
+++ b/content/memos/hilton/doubletree-tokyo-ariake/guest-room.md
@@ -25,19 +25,14 @@ og_cover: /images/2025/11/doubletree-ariake-1306-IMG_8125.jpg
 
 ## 写真
 
-### 部屋全体
 ![](/images/2025/11/doubletree-ariake-1306-IMG_8122.jpg)
 
-### デスク周り・ワークチェア
 ![](/images/2025/11/doubletree-ariake-1306-IMG_8123.jpg)
 
-### ベッド
 ![](/images/2025/11/doubletree-ariake-1306-IMG_8124.jpg)
 
-### 洗面・バスルーム
 ![](/images/2025/11/doubletree-ariake-1306-IMG_8125.jpg)
 
-### その他
 ![](/images/2025/11/doubletree-ariake-1306-IMG_8126.jpg)
 
 ## 部屋の設備・特徴

--- a/content/memos/hilton/doubletree-toyama/premium-twin.md
+++ b/content/memos/hilton/doubletree-toyama/premium-twin.md
@@ -33,27 +33,15 @@ og_cover: /images/2026/01/doubletree-toyama-1313-IMG_8235.jpg
 
 ## 写真
 
-### 部屋全体
-
 ![](/images/2026/01/doubletree-toyama-1313-IMG_8222.jpg)
-
-### テレビ・ミニバー
 
 ![](/images/2026/01/doubletree-toyama-1313-IMG_8225.jpg)
 
-### ネスプレッソマシン
-
 ![](/images/2026/01/doubletree-toyama-1313-IMG_8230.jpg)
-
-### バスルーム
 
 ![](/images/2026/01/doubletree-toyama-1313-IMG_8223.jpg)
 
-### 廊下・入口エリア
-
 ![](/images/2026/01/doubletree-toyama-1313-IMG_8224.jpg)
-
-### ベッドサイド
 
 ![](/images/2026/01/doubletree-toyama-1313-IMG_8236.jpg)
 
@@ -61,15 +49,9 @@ og_cover: /images/2026/01/doubletree-toyama-1313-IMG_8235.jpg
 
 ![](/images/2026/01/doubletree-toyama-1313-IMG_8229.jpg)
 
-### 作業環境
-
 ![](/images/2026/01/doubletree-toyama-1313-IMG_8231.jpg)
 
-### 眺望
-
 ![](/images/2026/01/doubletree-toyama-1313-IMG_8235.jpg)
-
-### 朝食
 
 ![](/images/2026/01/doubletree-toyama-1313-IMG_8232.jpg)
 


### PR DESCRIPTION
## Summary
- `## 写真` 配下の `### 部屋全体` 等の小見出しが、`.memo` の 2 カラムグリッドで全幅要素として配置されてしまい、画像セルの自動配置を毎回分断していた
- 結果、各画像が左カラムに 1 枚ずつ並んで右が常に空、というレイアウトになっていた
- 写真の説明見出しは副次的なので削除し、画像のみが 2 カラムに自然に並ぶようにする
- ついでに余分な連続空行も整理

## 対象ファイル
- content/memos/hilton/doubletree-tokyo-ariake/guest-room.md
- content/memos/hilton/doubletree-tokyo-ariake/guest-room-high-floor.md
- content/memos/hilton/doubletree-toyama/premium-twin.md

## Test plan
- [ ] `npm run dev` で対象 3 ページを確認
- [ ] 写真セクションが 2 カラムグリッドで隙間なく並ぶ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
