### PR TITLE
feat: 部屋メモの写真クリックでライトボックス表示

### DIFF
--- a/src/pages/memos/[...slug].astro
+++ b/src/pages/memos/[...slug].astro
@@ -221,6 +221,54 @@ const ogImage =
     <Content />
   )}
 
+  {kind === "memo" && (
+    <dialog class="lightbox" aria-label="拡大表示">
+      <button class="lightbox__close" type="button" aria-label="閉じる">×</button>
+      <button class="lightbox__prev" type="button" aria-label="前の写真">‹</button>
+      <img class="lightbox__img" alt="" />
+      <button class="lightbox__next" type="button" aria-label="次の写真">›</button>
+    </dialog>
+    <script>
+      const memo = document.querySelector(".memo")
+      const dialog = document.querySelector(".lightbox") as HTMLDialogElement | null
+      const dialogImg = dialog?.querySelector(".lightbox__img") as HTMLImageElement | null
+      const prevBtn = dialog?.querySelector(".lightbox__prev") as HTMLButtonElement | null
+      const nextBtn = dialog?.querySelector(".lightbox__next") as HTMLButtonElement | null
+      const closeBtn = dialog?.querySelector(".lightbox__close") as HTMLButtonElement | null
+      if (memo && dialog && dialogImg && prevBtn && nextBtn && closeBtn) {
+        const imgs = Array.from(memo.querySelectorAll("p > img")) as HTMLImageElement[]
+        let index = 0
+        const show = (i: number) => {
+          index = (i + imgs.length) % imgs.length
+          dialogImg.src = imgs[index].src
+        }
+        imgs.forEach((img, i) => {
+          img.style.cursor = "zoom-in"
+          img.addEventListener("click", () => {
+            show(i)
+            dialog.showModal()
+          })
+        })
+        prevBtn.addEventListener("click", (e) => {
+          e.stopPropagation()
+          show(index - 1)
+        })
+        nextBtn.addEventListener("click", (e) => {
+          e.stopPropagation()
+          show(index + 1)
+        })
+        closeBtn.addEventListener("click", () => dialog.close())
+        dialog.addEventListener("click", (e) => {
+          if (e.target === dialog) dialog.close()
+        })
+        dialog.addEventListener("keydown", (e) => {
+          if (e.key === "ArrowLeft") show(index - 1)
+          else if (e.key === "ArrowRight") show(index + 1)
+        })
+      }
+    </script>
+  )}
+
   {
     kind === "hotel" && hotelMemos.length > 0 && (
       <section>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1386,6 +1386,74 @@ main.home {
   }
 }
 
+/* --- lightbox --- */
+.lightbox {
+  border: 0;
+  padding: 0;
+  max-width: 100vw;
+  max-height: 100vh;
+  width: 100vw;
+  height: 100vh;
+  background: transparent;
+  overflow: hidden;
+}
+
+.lightbox::backdrop {
+  background: rgba(0, 0, 0, 0.85);
+}
+
+.lightbox__img {
+  display: block;
+  max-width: 92vw;
+  max-height: 92vh;
+  margin: auto;
+  position: absolute;
+  inset: 0;
+  object-fit: contain;
+  border-radius: 0;
+}
+
+.lightbox__close,
+.lightbox__prev,
+.lightbox__next {
+  position: absolute;
+  background: rgba(0, 0, 0, 0.4);
+  color: #fff;
+  border: 0;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: background 0.15s ease;
+}
+
+.lightbox__close:hover,
+.lightbox__prev:hover,
+.lightbox__next:hover {
+  background: rgba(0, 0, 0, 0.7);
+}
+
+.lightbox__close {
+  top: 1rem;
+  right: 1rem;
+}
+
+.lightbox__prev {
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.lightbox__next {
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 @media (max-width: 540px) {
   .chain-hotel {
     grid-template-columns: 72px 1fr auto;


### PR DESCRIPTION
## Summary
- 部屋メモページの写真をクリックすると `<dialog>` で拡大表示するライトボックスを追加
- 左右矢印キー / 左右ボタンで前後の写真に切り替え
- ESC / 背景クリック / × ボタンで閉じる
- ライブラリ非依存の素実装（`<dialog>` + 50行程度のスクリプト）

## Test plan
- [ ] 部屋メモページで画像をクリックして拡大表示できる
- [ ] 左右矢印キーで前後の写真に切り替わる
- [ ] ESC / 背景クリック / × ボタンで閉じられる
- [ ] 最初の写真で ← / 最後の写真で → を押すと循環する

🤖 Generated with [Claude Code](https://claude.com/claude-code)
