### PR TITLE
feat: 部屋メモ末尾に同じホテルの他のメモセクションを追加

### DIFF
--- a/src/pages/memos/[...slug].astro
+++ b/src/pages/memos/[...slug].astro
@@ -58,6 +58,9 @@ const hotelMemos =
 
 let parentHotelName: string | null = null
 let parentHotelHref: string | null = null
+const SIBLING_LIMIT = 6
+let siblingMemos: Awaited<ReturnType<typeof getCollection<"memos">>> = []
+let siblingTotal = 0
 if (kind === "memo" && memoPath) {
   const parentId = `memos/${memoPath.chain}/${memoPath.hotel}`
   const parentEntry = (await getCollection("hotels")).find(
@@ -67,6 +70,20 @@ if (kind === "memo" && memoPath) {
     parentEntry?.data.title ??
     (parentEntry ? (extractH1(parentEntry.body) ?? memoPath.hotel) : memoPath.hotel)
   parentHotelHref = `/${parentId}/`
+
+  const all = (await getCollection("memos"))
+    .filter((m) => !m.data.draft)
+    .filter((m) => m.id.startsWith(parentId + "/"))
+    .filter((m) => m.id !== entry.id)
+  siblingTotal = all.length
+  siblingMemos = all
+    .sort((a, b) => {
+      if (b.data.rating !== a.data.rating) return b.data.rating - a.data.rating
+      const ad = a.data.stayed_at?.getTime() ?? 0
+      const bd = b.data.stayed_at?.getTime() ?? 0
+      return bd - ad
+    })
+    .slice(0, SIBLING_LIMIT)
 }
 
 const formatYM = (d: Date) =>
@@ -219,6 +236,41 @@ const ogImage =
     </div>
   ) : (
     <Content />
+  )}
+
+  {kind === "memo" && siblingTotal > 0 && (
+    <section class="sibling-memos">
+      <span class="section-label">
+        {parentHotelName} の他のメモ（{siblingTotal}件）
+      </span>
+      <ul>
+        {siblingMemos.map((m) => (
+          <li>
+            {m.data.cover ? (
+              <img class="thumb" src={m.data.cover} alt="" />
+            ) : (
+              <span class="thumb" aria-hidden="true"></span>
+            )}
+            <div class="meta">
+              <span class="stars">
+                <span class="on">{"★".repeat(m.data.rating)}</span><span class="off">{"☆".repeat(5 - m.data.rating)}</span>
+              </span>
+              <span class="date">
+                {m.data.stayed_at ? formatYM(m.data.stayed_at) : "—"}
+              </span>
+            </div>
+            <span class="title">
+              <a href={`/memos/${m.id.replace(/^memos\//, "")}/`}>{m.data.title}</a>
+            </span>
+          </li>
+        ))}
+      </ul>
+      {siblingTotal > SIBLING_LIMIT && parentHotelHref && (
+        <p class="sibling-memos__more">
+          <a href={parentHotelHref}>+ {siblingTotal - SIBLING_LIMIT}件 →</a>
+        </p>
+      )}
+    </section>
   )}
 
   {kind === "memo" && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1491,3 +1491,93 @@ main.home {
   color: var(--text);
   font-weight: 500;
 }
+
+/* 部屋メモ末尾: 同じホテルの他のメモ */
+.sibling-memos {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--line);
+}
+
+.sibling-memos .section-label {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  margin-bottom: 0.9rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 2px solid var(--accent);
+}
+
+.sibling-memos ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.sibling-memos li {
+  display: grid;
+  grid-template-columns: 84px 7.5em 1fr;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--line);
+}
+.sibling-memos li:last-child { border-bottom: 0; }
+
+.sibling-memos .thumb {
+  width: 84px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 6px;
+  background: var(--highlight);
+  display: block;
+  margin: 0;
+}
+
+.sibling-memos .meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.sibling-memos .stars {
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+}
+.sibling-memos .stars .on  { color: var(--star); }
+.sibling-memos .stars .off { color: var(--star-empty); }
+
+.sibling-memos .date {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.sibling-memos .title {
+  font-size: 0.95rem;
+  font-weight: 500;
+  line-height: 1.45;
+}
+.sibling-memos .title a { color: var(--accent); }
+
+.sibling-memos__more {
+  margin: 0.9rem 0 0;
+  font-size: 0.85rem;
+}
+.sibling-memos__more a {
+  color: var(--accent);
+  font-weight: 500;
+}
+
+@media (max-width: 540px) {
+  .sibling-memos li {
+    grid-template-columns: 64px 5.5em 1fr;
+    gap: 0.6rem;
+  }
+  .sibling-memos .thumb { width: 64px; height: 44px; }
+}


### PR DESCRIPTION
## Summary
- 部屋メモページの末尾に「同じホテルの他のメモ」セクションを追加
- 並び順: ★高い順 → `stayed_at` 新しい順
- 最大 6 件まで表示。それ以上ある場合は末尾に「+ N件 →」リンクで親ホテルページへ
- 同じホテルに自分以外のメモが 0 件の場合はセクション自体が出ない

## Test plan
- [ ] シーホーク等の複数メモあるホテルでセクションが出る
- [ ] 単独メモのホテルではセクションが出ない
- [ ] ★高い順 → 日付新しい順で並ぶ
- [ ] サムネ・★+日付・タイトルの 3 カラム

🤖 Generated with [Claude Code](https://claude.com/claude-code)
