### PR TITLE
feat: regions ページのホテル見出しに実宿泊バッジを自動付与

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import { remarkAlert } from "remark-github-blockquote-alert"
 import remarkRewriteLinks from "./src/lib/remark-rewrite-links.mjs"
 import rehypeSlug from "rehype-slug"
 import rehypeStayDate from "./src/lib/rehype-stay-date.mjs"
+import rehypeStayedBadge from "./src/lib/rehype-stayed-badge.mjs"
 
 export default defineConfig({
   site: "https://hotel-memo.github.io",
@@ -12,7 +13,7 @@ export default defineConfig({
   integrations: [mdx(), sitemap()],
   markdown: {
     remarkPlugins: [remarkAlert, remarkRewriteLinks],
-    rehypePlugins: [rehypeSlug, rehypeStayDate],
+    rehypePlugins: [rehypeSlug, rehypeStayDate, rehypeStayedBadge],
     shikiConfig: {
       theme: "github-light",
     },

--- a/src/lib/rehype-stayed-badge.mjs
+++ b/src/lib/rehype-stayed-badge.mjs
@@ -1,0 +1,59 @@
+import { visit } from "unist-util-visit"
+
+export default function rehypeStayedBadge() {
+  return (tree, file) => {
+    const path = file?.path ?? file?.history?.[0] ?? ""
+    if (!path.includes("/regions/")) return
+
+    visit(tree, "element", (h3, index, parent) => {
+      if (h3.tagName !== "h3" || !parent || index == null) return
+
+      let i = index + 1
+      while (i < parent.children.length) {
+        const c = parent.children[i]
+        if (c.type === "element") break
+        if (c.type === "text" && c.value.trim()) return
+        i++
+      }
+      const ul = parent.children[i]
+      if (!ul || ul.type !== "element" || ul.tagName !== "ul") return
+
+      const hasMemo = ul.children.some(
+        (li) =>
+          li.type === "element" &&
+          li.tagName === "li" &&
+          li.children?.some(
+            (c) =>
+              c.type === "element" &&
+              c.tagName === "strong" &&
+              textOf(c).trim() === "メモ",
+          ),
+      )
+      if (!hasMemo) return
+
+      const already = h3.children.some(
+        (c) =>
+          c.type === "element" &&
+          asArray(c.properties?.className).includes("badge-stayed"),
+      )
+      if (already) return
+
+      h3.children.push({
+        type: "element",
+        tagName: "span",
+        properties: { className: ["badge-stayed"] },
+        children: [{ type: "text", value: "実宿泊" }],
+      })
+    })
+  }
+}
+
+function textOf(node) {
+  if (node.type === "text") return node.value
+  if (!node.children) return ""
+  return node.children.map(textOf).join("")
+}
+
+function asArray(v) {
+  return Array.isArray(v) ? v : v ? [v] : []
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -685,6 +685,16 @@ main.home {
   line-height: 1.4;
   color: var(--text);
   margin: 1.6rem 0 0.4rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.regions h3 .badge-stayed {
+  font-size: 0.65rem;
+  padding: 0.18rem 0.5rem;
+  transform: translateY(-2px);
 }
 
 .regions h3 + ul {


### PR DESCRIPTION
## Summary
- `rehype-stayed-badge` プラグインを新規追加し、regions コレクションの `### ホテル名` 直下の `<ul>` に `- **メモ**:` 行があるホテル見出しに `[実宿泊]` バッジを自動表示
- `.regions h3` を flex 化してバッジを横並びに、バッジサイズを少し縮めて見出しに馴染ませる
- マークダウン側の変更は不要

## Test plan
- [ ] `/regions/kanto/` などで「メモ」行を持つホテル見出しに「実宿泊」バッジが出る
- [ ] 推測のみのホテル（メモ行なし）にはバッジが出ない
- [ ] バッジの色・形は memo ヒーローの `.badge-stayed` と揃っている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
