### PR TITLE
fix: ギャラリー画像のライトボックス対応

### DIFF
--- a/src/pages/memos/[...slug].astro
+++ b/src/pages/memos/[...slug].astro
@@ -288,7 +288,7 @@ const ogImage =
       const nextBtn = dialog?.querySelector(".lightbox__next") as HTMLButtonElement | null
       const closeBtn = dialog?.querySelector(".lightbox__close") as HTMLButtonElement | null
       if (memo && dialog && dialogImg && prevBtn && nextBtn && closeBtn) {
-        const imgs = Array.from(memo.querySelectorAll("p > img")) as HTMLImageElement[]
+        const imgs = Array.from(memo.querySelectorAll("p > img, .memo-gallery > img")) as HTMLImageElement[]
         let index = 0
         const show = (i: number) => {
           index = (i + imgs.length) % imgs.length


### PR DESCRIPTION
## Summary
- ギャラリー化で画像が `<p>` から `<div.memo-gallery>` 直下に移動したため、ライトボックスのセレクタに `.memo-gallery > img` を追加

## Test plan
- [x] ギャラリー内の画像クリックで拡大表示される
- [x] 矢印キー・ボタンで前後の画像に移動できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)